### PR TITLE
Use require_once instead of import

### DIFF
--- a/sysplugins/smarty_internal_smartytemplatecompiler.php
+++ b/sysplugins/smarty_internal_smartytemplatecompiler.php
@@ -11,7 +11,7 @@
 /**
  * @ignore
  */
-include 'smarty_internal_parsetree.php';
+require_once('smarty_internal_parsetree.php');
 
 /**
  * Class SmartyTemplateCompiler


### PR DESCRIPTION
Use require_once instead of include and require, otherwise phpunit code coverage analysis will not work properly
